### PR TITLE
Compress images before encoding

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'nearby_ads_service.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:image/image.dart' as img;
 
 void main() {
   runApp(const MyApp());
@@ -141,9 +142,13 @@ class _MyAdsPageState extends State<MyAdsPage> {
     final file = await picker.pickImage(source: ImageSource.gallery);
     if (file != null) {
       final bytes = await file.readAsBytes();
-      setState(() {
-        _imageBase64 = base64Encode(bytes);
-      });
+      final image = img.decodeImage(bytes);
+      if (image != null) {
+        final compressed = img.encodeJpg(image, quality: 60);
+        setState(() {
+          _imageBase64 = base64Encode(compressed);
+        });
+      }
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   shared_preferences: ^2.2.2
   url_launcher: ^6.2.6
   image_picker: ^1.0.7
+  image: ^4.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- compress images using `image` package before encoding to base64
- add `image` dependency to `pubspec.yaml`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684486d6896c8327bc0162e61a175cd1