### PR TITLE
Fix pubspec errors and update location plugin

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,10 +38,9 @@ dependencies:
   cupertino_icons: ^1.0.8
   flutter_ble_peripheral: ^1.2.6
   flutter_blue_plus: ^1.35.5
-  flutter_local_notifications: ^19.2.1
   permission_handler: ^11.3.1
   device_info_plus: ^11.4.0
-  location: ^4.4.0
+  location: ^8.0.0
   shared_preferences: ^2.2.2
   url_launcher: ^6.2.6
   image_picker: ^1.0.7


### PR DESCRIPTION
## Summary
- remove duplicate `flutter_local_notifications` entry
- upgrade `location` package to latest version (8.0.0)

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6844915390b883279a688b1179e5aa36