### PR TITLE
Support fetching full ads via HTTP

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -277,11 +277,28 @@ class ReceivedPage extends StatelessWidget {
                   : null,
           title: Text(a.title),
           subtitle: Text('${a.description}\nPrice: ${a.price}'),
-          trailing: IconButton(
-            icon: const Icon(Icons.delete),
-            onPressed: () {
-              service.removeReceivedAnnouncement(a);
-            },
+          onTap: () {
+            if (a.imageBase64 == null && a.serverUrl != null) {
+              service.fetchFullAnnouncement(a);
+            }
+          },
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (a.imageBase64 == null && a.serverUrl != null)
+                IconButton(
+                  icon: const Icon(Icons.download),
+                  onPressed: () {
+                    service.fetchFullAnnouncement(a);
+                  },
+                ),
+              IconButton(
+                icon: const Icon(Icons.delete),
+                onPressed: () {
+                  service.removeReceivedAnnouncement(a);
+                },
+              ),
+            ],
           ),
         );
       }).toList(),

--- a/lib/models/announcement.dart
+++ b/lib/models/announcement.dart
@@ -5,6 +5,7 @@ class Announcement {
   final double price;
   final String? imageUrl;
   final String? imageBase64;
+  final String? serverUrl;
   Announcement({
     required this.id,
     required this.title,
@@ -12,6 +13,7 @@ class Announcement {
     required this.price,
     this.imageUrl,
     this.imageBase64,
+    this.serverUrl,
   });
 
   factory Announcement.fromJson(Map<String, dynamic> json) {
@@ -22,6 +24,7 @@ class Announcement {
       price: (json['price'] as num).toDouble(),
       imageUrl: json['imageUrl'] as String?,
       imageBase64: json['imageBase64'] as String?,
+      serverUrl: json['serverUrl'] as String?,
     );
   }
 
@@ -32,5 +35,35 @@ class Announcement {
         'price': price,
         'imageUrl': imageUrl,
         'imageBase64': imageBase64,
+        'serverUrl': serverUrl,
       };
+
+  Map<String, dynamic> toAdvertiseJson() => {
+        'id': id,
+        'title': title,
+        'description': description,
+        'price': price,
+        'imageUrl': imageUrl,
+        'serverUrl': serverUrl,
+      };
+
+  Announcement copyWith({
+    String? id,
+    String? title,
+    String? description,
+    double? price,
+    String? imageUrl,
+    String? imageBase64,
+    String? serverUrl,
+  }) {
+    return Announcement(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      price: price ?? this.price,
+      imageUrl: imageUrl ?? this.imageUrl,
+      imageBase64: imageBase64 ?? this.imageBase64,
+      serverUrl: serverUrl ?? this.serverUrl,
+    );
+  }
 }

--- a/lib/nearby_ads_service.dart
+++ b/lib/nearby_ads_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_ble_peripheral/flutter_ble_peripheral.dart';
@@ -9,7 +10,7 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:location/location.dart';
-import 'dart:io';
+import 'package:http/http.dart' as http;
 
 import 'models/announcement.dart';
 
@@ -53,6 +54,9 @@ class NearbyAdsService extends ChangeNotifier {
   List<Uint8List> _advertiseChunks = [];
   int _advertiseIndex = 0;
   final Map<int, _ChunkAssembly> _assemblies = {};
+
+  HttpServer? _server;
+  String? _serverBaseUrl;
 
   static const int _manufacturerId = 0xFFFF;
 
@@ -155,7 +159,11 @@ class NearbyAdsService extends ChangeNotifier {
 
   Future<void> startAdvertising(Announcement ad) async {
     selected = ad;
-    final jsonStr = jsonEncode(ad.toJson());
+    await _startServer();
+    final advertiseMap = ad
+        .copyWith(serverUrl: '$_serverBaseUrl/announcement/${ad.id}')
+        .toAdvertiseJson();
+    final jsonStr = jsonEncode(advertiseMap);
     final bytes = Uint8List.fromList(utf8.encode(jsonStr));
     const payloadSize = 20;
     final total = (bytes.length / payloadSize).ceil();
@@ -229,7 +237,62 @@ class NearbyAdsService extends ChangeNotifier {
     await _peripheral.stop();
     _advertiseTimer?.cancel();
     _advertiseChunks = [];
+    await _stopServer();
     notifyListeners();
+  }
+
+  Future<void> _startServer() async {
+    if (_server != null) return;
+    final interfaces = await NetworkInterface.list(type: InternetAddressType.IPv4);
+    final addr = interfaces
+        .expand((e) => e.addresses)
+        .firstWhere((a) => !a.isLoopback, orElse: () => InternetAddress.anyIPv4);
+    _server = await HttpServer.bind(InternetAddress.anyIPv4, 0);
+    _serverBaseUrl = 'http://${addr.address}:${_server!.port}';
+    _server!.listen((req) async {
+      final segments = req.uri.pathSegments;
+      if (segments.length == 2 && segments.first == 'announcement') {
+        final id = segments[1];
+        final ad = announcements.firstWhere(
+          (a) => a.id == id,
+          orElse: () => Announcement(
+            id: id,
+            title: '',
+            description: '',
+            price: 0,
+          ),
+        );
+        final jsonStr = jsonEncode(ad.toJson());
+        req.response.headers.contentType = ContentType.json;
+        req.response.write(jsonStr);
+      } else {
+        req.response.statusCode = HttpStatus.notFound;
+      }
+      await req.response.close();
+    });
+  }
+
+  Future<void> _stopServer() async {
+    await _server?.close();
+    _server = null;
+    _serverBaseUrl = null;
+  }
+
+  Future<void> fetchFullAnnouncement(Announcement ad) async {
+    if (ad.serverUrl == null) return;
+    try {
+      final uri = Uri.parse(ad.serverUrl!);
+      final res = await http.get(uri);
+      if (res.statusCode == 200) {
+        final map = jsonDecode(res.body) as Map<String, dynamic>;
+        final fullAd = Announcement.fromJson(map);
+        final index = receivedAnnouncements.indexWhere((a) => a.id == ad.id);
+        if (index != -1) {
+          receivedAnnouncements[index] = fullAd;
+          notifyListeners();
+        }
+      }
+    } catch (_) {}
   }
 
   Future<void> _startScanning() async {
@@ -275,6 +338,7 @@ class NearbyAdsService extends ChangeNotifier {
     await FlutterBluePlus.stopScan();
     await _scanSub?.cancel();
     _advertiseTimer?.cancel();
+    await _stopServer();
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   url_launcher: ^6.2.6
   image_picker: ^1.0.7
   image: ^4.1.3
+  http: ^0.13.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `http` dependency
- let announcements hold optional `serverUrl`
- advertise lightweight JSON that contains a URL to fetch the full ad
- start a simple local `HttpServer` when advertising
- allow receiving devices to request the complete announcement

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449c22e8bc83279185c7ccb581b920