### PR TITLE
Add BLE connection and WiFi VoIP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ only requested on Android versions prior to 12.
 ## BLE Advertising Example
 
 For a guide on building a simple application that exchanges detailed sale announcements (title, description, price, image and phone number) via Bluetooth Low Energy, see [docs/ble_annonces_ble.md](docs/ble_annonces_ble.md).
+
+The application now includes a Bluetooth connection that fetches the advertised photo using a custom GATT service. Once connected, a peer to peer voice call can be started over Wi-Fi using WebRTC.

--- a/docs/ble_connexion_photo_appel.md
+++ b/docs/ble_connexion_photo_appel.md
@@ -1,0 +1,101 @@
+# Connexion Bluetooth avec photo et appel
+
+Ce document explique comment étendre l'exemple d'annonces BLE afin de permettre
+au téléphone qui reçoit une annonce de se connecter en Bluetooth à l'appareil
+diffuseur. L'objectif est de récupérer l'image associée à l'annonce et de
+proposer un bouton d'appel vers le diffuseur.
+
+## 1. Service GATT sur le diffuseur
+
+En plus de la diffusion via `flutter_ble_peripheral`, l'appareil qui partage
+l'annonce peut exposer un petit serveur BLE (service GATT) pour fournir des
+informations détaillées.
+
+1. Définissez un UUID de service personnalisé, par exemple
+   `0000abcd-0000-1000-8000-00805f9b34fb`.
+2. Créez deux caractéristiques :
+   - **Annonce** (`0000abcd-0001-1000-8000-00805f9b34fb`) contenant le JSON
+     complet de l'annonce (incluant `imageBase64` si l'image doit être
+     transférée hors connexion).
+   - **Image** (`0000abcd-0002-1000-8000-00805f9b34fb`) pour envoyer les octets
+de l'image si elle est trop volumineuse pour être incluse dans le JSON.
+3. Utilisez une bibliothèque comme `flutter_gatt_server` (Android uniquement) ou
+   un plugin équivalent pour publier ce service.
+
+```dart
+final serviceUuid = Guid('0000abcd-0000-1000-8000-00805f9b34fb');
+final adChar = Characteristic(
+  uuid: Guid('0000abcd-0001-1000-8000-00805f9b34fb'),
+  value: utf8.encode(jsonEncode(ad.toJson())),
+);
+final imageChar = Characteristic(
+  uuid: Guid('0000abcd-0002-1000-8000-00805f9b34fb'),
+  value: imageBytes,
+);
+GattServer().addService(BleService(serviceUuid, [adChar, imageChar]));
+```
+
+## 2. Connexion côté récepteur
+
+Lorsqu'un appareil détecte une annonce grâce au paquet publicitaire, il peut se
+connecter à l'annonceur avec `flutter_blue_plus` pour récupérer les données
+supplémentaires :
+
+```dart
+Future<Announcement?> fetchFullAd(ScanResult result) async {
+  final device = result.device;
+  await device.connect();
+
+  final services = await device.discoverServices();
+  final service = services.firstWhere(
+    (s) => s.serviceUuid.toString() ==
+        '0000abcd-0000-1000-8000-00805f9b34fb',
+  );
+
+  final adData = await service
+      .characteristics
+      .firstWhere((c) =>
+          c.uuid.toString() == '0000abcd-0001-1000-8000-00805f9b34fb')
+      .read();
+
+  final imgBytes = await service
+      .characteristics
+      .firstWhere((c) =>
+          c.uuid.toString() == '0000abcd-0002-1000-8000-00805f9b34fb')
+      .read();
+
+  final map = jsonDecode(utf8.decode(adData));
+  map['imageBase64'] = base64Encode(imgBytes);
+  await device.disconnect();
+
+  return Announcement.fromJson(map);
+}
+```
+
+L'image est ensuite affichée avec `Image.memory` :
+
+```dart
+Image.memory(base64Decode(ad.imageBase64!));
+```
+
+## 3. Appeler le diffuseur
+
+Une fois l'annonce complète récupérée, l'application initie un appel audio pair
+à pair via Wi-Fi en utilisant WebRTC. Le diffuseur lance un petit serveur HTTP
+local pour échanger l'offre et la réponse SDP :
+
+```dart
+await voipService.startServer(); // côté diffuseur
+
+// côté récepteur
+await voipService.call(ad.ip!);
+```
+
+La communication passe alors par le réseau local sans nécessiter le réseau
+téléphonique.
+
+---
+
+Cette approche ajoute une étape de connexion BLE pour accéder aux informations
+complètes et fonctionne hors connexion Internet lorsque les deux appareils sont à
+proximité.

--- a/lib/gatt_server_helper.dart
+++ b/lib/gatt_server_helper.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:ble_gatt_server/ble_gatt_server.dart';
+
+import 'models/announcement.dart';
+
+class GattServerHelper {
+  static const serviceUuid = '0000abcd-0000-1000-8000-00805f9b34fb';
+  static const adCharUuid = '0000abcd-0001-1000-8000-00805f9b34fb';
+  static const imageCharUuid = '0000abcd-0002-1000-8000-00805f9b34fb';
+
+  final BleGattServer _server = BleGattServer();
+  final Map<String, Uint8List?> _values = {};
+
+  Future<void> start(Announcement ad, Uint8List? imageBytes) async {
+    final adChar = BleGattCharacteristic(
+      uuid: adCharUuid,
+      properties: BleGattCharacteristic.PROPERTY_READ,
+      permissions: BleGattCharacteristic.PERMISSION_READ,
+      descriptors: [],
+    );
+    final imgChar = BleGattCharacteristic(
+      uuid: imageCharUuid,
+      properties: BleGattCharacteristic.PROPERTY_READ,
+      permissions: BleGattCharacteristic.PERMISSION_READ,
+      descriptors: [],
+    );
+
+    _values[adChar.uuid] =
+        Uint8List.fromList(utf8.encode(jsonEncode(ad.toJson())));
+    _values[imgChar.uuid] = imageBytes;
+
+    await _server.startServer();
+    await _server.addService(
+      BleGattService(
+        uuid: serviceUuid,
+        serviceType: BleGattService.SERVICE_TYPE_PRIMARY,
+        characteristics: [adChar, imgChar],
+      ),
+    );
+
+    _server.handleEvents(
+      onCharacteristicReadRequest:
+          (device, requestId, offset, characteristic) async {
+        final data = _values[characteristic?.uuid] ?? Uint8List(0);
+        await _server.sendResponse(
+            device!, requestId, BleGattServer.GATT_SUCCESS, offset, data);
+      },
+    );
+  }
+
+  Future<void> stop() => _server.stopServer();
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'models/announcement.dart';
 import 'nearby_ads_service.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'dart:convert';
 
 void main() {
   runApp(const MyApp());
@@ -232,14 +232,40 @@ class ReceivedPage extends StatelessWidget {
               : null,
           title: Text(a.title),
           subtitle: Text('${a.description}\nPrice: ${a.price}'),
-          trailing: a.phone != null
-              ? IconButton(
-                  icon: const Icon(Icons.phone),
-                  onPressed: () {
-                    launchUrl(Uri.parse('tel:${a.phone}'));
-                  },
-                )
-              : null,
+          onTap: () async {
+            final full = await service.fetchFullAnnouncement(a.id);
+            if (full == null) return;
+            showDialog(
+              context: context,
+              builder: (context) {
+                return AlertDialog(
+                  title: Text(full.title),
+                  content: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (full.imageUrl != null)
+                        Image.memory(base64Decode(full.imageUrl!)),
+                      Text(full.description),
+                      Text('Price: ${full.price}'),
+                    ],
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(context),
+                      child: const Text('Fermer'),
+                    ),
+                    if (full.ip != null)
+                      TextButton(
+                        onPressed: () {
+                          service.voipService.call(full.ip!);
+                        },
+                        child: const Text('Appel Wi-Fi'),
+                      ),
+                  ],
+                );
+              },
+            );
+          },
         );
       }).toList(),
     );

--- a/lib/models/announcement.dart
+++ b/lib/models/announcement.dart
@@ -5,6 +5,7 @@ class Announcement {
   final double price;
   final String? imageUrl;
   final String? phone;
+  final String? ip;
 
   Announcement({
     required this.id,
@@ -13,6 +14,7 @@ class Announcement {
     required this.price,
     this.imageUrl,
     this.phone,
+    this.ip,
   });
 
   factory Announcement.fromJson(Map<String, dynamic> json) {
@@ -23,6 +25,7 @@ class Announcement {
       price: (json['price'] as num).toDouble(),
       imageUrl: json['imageUrl'] as String?,
       phone: json['phone'] as String?,
+      ip: json['ip'] as String?,
     );
   }
 
@@ -33,5 +36,6 @@ class Announcement {
         'price': price,
         'imageUrl': imageUrl,
         'phone': phone,
+        'ip': ip,
       };
 }

--- a/lib/nearby_ads_service.dart
+++ b/lib/nearby_ads_service.dart
@@ -1,6 +1,11 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
+import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'package:uuid/uuid.dart';
+import 'gatt_server_helper.dart';
+import 'voip_service.dart';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_ble_peripheral/flutter_ble_peripheral.dart';
@@ -8,7 +13,6 @@ import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:device_info_plus/device_info_plus.dart';
-import 'dart:io';
 
 import 'models/announcement.dart';
 
@@ -22,6 +26,9 @@ enum AdsState { idle, ready, permissionDenied }
 
 class NearbyAdsService extends ChangeNotifier {
   final FlutterBlePeripheral _peripheral = FlutterBlePeripheral();
+  final Map<String, ScanResult> _resultMap = {};
+  final GattServerHelper _gatt = GattServerHelper();
+  final VoipService voipService = VoipService();
 
   AdsState state = AdsState.idle;
   final List<Announcement> receivedAnnouncements = [];
@@ -67,6 +74,7 @@ class NearbyAdsService extends ChangeNotifier {
                 try {
                   final map = jsonDecode(jsonStr) as Map<String, dynamic>;
                   final ad = Announcement.fromJson(map);
+                  _resultMap[ad.id] = result;
                   if (receivedAnnouncements
                       .every((existing) => existing.id != ad.id)) {
                     receivedAnnouncements.add(ad);
@@ -111,6 +119,7 @@ class NearbyAdsService extends ChangeNotifier {
             try {
               final map = jsonDecode(jsonStr) as Map<String, dynamic>;
               final ad = Announcement.fromJson(map);
+              _resultMap[ad.id] = result;
               if (receivedAnnouncements
                   .every((existing) => existing.id != ad.id)) {
                 receivedAnnouncements.add(ad);
@@ -142,13 +151,15 @@ class NearbyAdsService extends ChangeNotifier {
     String? imageUrl,
     String? phone,
   }) async {
+    final ip = await _getLocalIp();
     final ad = Announcement(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      id: const Uuid().v4(),
       title: title,
       description: description,
       price: price,
       imageUrl: imageUrl,
       phone: phone,
+      ip: ip,
     );
     announcements.add(ad);
     await _saveAnnouncements();
@@ -176,6 +187,17 @@ class NearbyAdsService extends ChangeNotifier {
     selected = ad;
     final jsonStr = jsonEncode(ad.toJson());
     final bytes = Uint8List.fromList(utf8.encode(jsonStr));
+    Uint8List? imageBytes;
+    if (ad.imageUrl != null && ad.imageUrl!.isNotEmpty) {
+      try {
+        final resp = await http.get(Uri.parse(ad.imageUrl!));
+        if (resp.statusCode == 200) {
+          imageBytes = resp.bodyBytes;
+        }
+      } catch (_) {}
+    }
+    await _gatt.start(ad, imageBytes);
+    await voipService.startServer();
     await _peripheral.start(
       advertiseData: AdvertiseData(
         manufacturerId: _manufacturerId,
@@ -189,7 +211,36 @@ class NearbyAdsService extends ChangeNotifier {
   Future<void> stopAdvertising() async {
     selected = null;
     await _peripheral.stop();
+    await _gatt.stop();
+    await voipService.dispose();
     notifyListeners();
+  }
+
+  Future<Announcement?> fetchFullAnnouncement(String id) async {
+    final result = _resultMap[id];
+    if (result == null) return null;
+    final device = result.device;
+    await device.connect();
+    Announcement? ad;
+    try {
+      final services = await device.discoverServices();
+      final service = services.firstWhere(
+          (s) => s.serviceUuid.toString() == GattServerHelper.serviceUuid,
+          orElse: () => throw Exception('service not found'));
+      final adData = await service.characteristics
+          .firstWhere((c) => c.uuid.toString() == GattServerHelper.adCharUuid)
+          .read();
+      final imgBytes = await service.characteristics
+          .firstWhere((c) => c.uuid.toString() == GattServerHelper.imageCharUuid)
+          .read();
+      final map = jsonDecode(utf8.decode(adData));
+      map['imageUrl'] = imgBytes.isNotEmpty ? base64Encode(imgBytes) : null;
+      ad = Announcement.fromJson(map);
+    } catch (_) {
+      // ignore
+    }
+    await device.disconnect();
+    return ad;
   }
 
   void _startScanning() {
@@ -205,6 +256,19 @@ class NearbyAdsService extends ChangeNotifier {
     final prefs = await SharedPreferences.getInstance();
     final json = jsonEncode(announcements.map((e) => e.toJson()).toList());
     await prefs.setString('announcements', json);
+  }
+
+  Future<String?> _getLocalIp() async {
+    final interfaces = await NetworkInterface.list(
+        type: InternetAddressType.IPv4, includeLoopback: false);
+    for (final interface in interfaces) {
+      for (final addr in interface.addresses) {
+        if (!addr.isLoopback) {
+          return addr.address;
+        }
+      }
+    }
+    return null;
   }
 
   Future<void> _loadAnnouncements() async {

--- a/lib/voip_service.dart
+++ b/lib/voip_service.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+
+class VoipService {
+  RTCPeerConnection? _peer;
+  MediaStream? _localStream;
+  HttpServer? _server;
+
+  Future<void> _createPeer() async {
+    if (_peer != null) return;
+    _peer = await createPeerConnection({'iceServers': []});
+    _localStream =
+        await navigator.mediaDevices.getUserMedia({'audio': true});
+    for (var track in _localStream!.getTracks()) {
+      await _peer!.addTrack(track, _localStream!);
+    }
+  }
+
+  Future<void> startServer() async {
+    await _createPeer();
+    _server = await HttpServer.bind(InternetAddress.anyIPv4, 8080);
+    _server!.listen((HttpRequest request) async {
+      if (request.method == 'POST' && request.uri.path == '/offer') {
+        final body = await utf8.decoder.bind(request).join();
+        final data = jsonDecode(body);
+        await _peer!.setRemoteDescription(
+            RTCSessionDescription(data['sdp'], data['type']));
+        final answer = await _peer!.createAnswer();
+        await _peer!.setLocalDescription(answer);
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..write(jsonEncode({'sdp': answer.sdp, 'type': answer.type}))
+          ..close();
+      } else {
+        request.response
+          ..statusCode = HttpStatus.notFound
+          ..close();
+      }
+    });
+  }
+
+  Future<void> call(String ip) async {
+    await _createPeer();
+    final offer = await _peer!.createOffer();
+    await _peer!.setLocalDescription(offer);
+    final client = HttpClient();
+    final req = await client.postUrl(Uri.parse('http://$ip:8080/offer'));
+    req.headers.contentType = ContentType.json;
+    req.write(jsonEncode({'sdp': offer.sdp, 'type': offer.type}));
+    final resp = await req.close();
+    final respBody = await resp.transform(utf8.decoder).join();
+    final data = jsonDecode(respBody);
+    await _peer!
+        .setRemoteDescription(RTCSessionDescription(data['sdp'], data['type']));
+  }
+
+  Future<void> dispose() async {
+    await _server?.close();
+    await _localStream?.dispose();
+    await _peer?.close();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,10 @@ dependencies:
   device_info_plus: ^11.4.0
   shared_preferences: ^2.2.2
   url_launcher: ^6.2.6
+  http: ^1.4.0
+  uuid: ^4.5.1
+  ble_gatt_server: ^0.1.0
+  flutter_webrtc: ^0.14.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add GATT server helper and VoIP service
- expose local IP in announcements
- fetch full ad via BLE and enable Wi-Fi call
- document new Wi-Fi call workflow in README and guide

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a1fd5a348327b35e234886c08d85