### PR TITLE
Fix P2P permission error and overflow

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <!-- Required permissions for BLE advertising and scanning -->
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
@@ -7,6 +8,19 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <!-- Permissions required for Wi-Fi Direct (P2P) -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <!-- Nearby devices permission for Android 13+ -->
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="33" />
+    <!-- Declare required hardware features -->
+    <uses-feature android:name="android.hardware.wifi" android:required="true" />
+    <uses-feature android:name="android.hardware.bluetooth" android:required="true" />
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
     <application
         android:label="xchange"
         android:name="${applicationName}"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -157,8 +157,10 @@ class _MyAdsPageState extends State<MyAdsPage> {
         ),
         Padding(
           padding: const EdgeInsets.all(8.0),
-          child: Column(
-            children: [
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
               TextField(
                 controller: _titleController,
                 decoration: const InputDecoration(labelText: 'Title'),
@@ -211,6 +213,7 @@ class _MyAdsPageState extends State<MyAdsPage> {
               ),
             ],
           ),
+        ),
         ),
       ],
     );


### PR DESCRIPTION
## Summary
- add missing Wi‑Fi related permissions for Wi‑Fi Direct
- declare required hardware features
- wrap ad creation form in `SingleChildScrollView`

## Testing
- `dart format -o none --set-exit-if-changed lib/main.dart android/app/src/main/AndroidManifest.xml` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b2329f3c83278cbf89be247fcb21