### PR TITLE
Fix server rebinding when changing ads

### DIFF
--- a/lib/ad_http_server.dart
+++ b/lib/ad_http_server.dart
@@ -7,7 +7,13 @@ class AdHttpServer {
   HttpServer? _server;
 
   Future<void> start(Announcement ad) async {
-    _server = await HttpServer.bind(InternetAddress.anyIPv4, 8081);
+    // Ensure any previous server is closed before starting a new one
+    await stop();
+    _server = await HttpServer.bind(
+      InternetAddress.anyIPv4,
+      8081,
+      shared: true,
+    );
     _server!.listen((HttpRequest request) async {
       if (request.uri.path == '/announcement') {
         request.response.headers.contentType = ContentType.json;

--- a/lib/nearby_ads_service.dart
+++ b/lib/nearby_ads_service.dart
@@ -183,10 +183,18 @@ class NearbyAdsService extends ChangeNotifier {
       await stopAdvertising();
       return;
     }
+    // If another announcement is currently being advertised, stop it first
+    if (selected != null) {
+      await stopAdvertising();
+    }
     await startAdvertising(ad);
   }
 
   Future<void> startAdvertising(Announcement ad) async {
+    // Ensure any previous advertisement is stopped before starting a new one
+    if (selected != null) {
+      await stopAdvertising();
+    }
     selected = ad;
     final hostState = await _p2pHost.createGroup(advertise: false);
     final updated = Announcement(


### PR DESCRIPTION
## Summary
- fix HTTP server start logic to always close previous server and use `shared: true`
- stop previous advertisement before selecting or starting a new one

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b45bfa888327a660c81b59ebab1a