### PR TITLE
Fix P2P permission request

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ only requested on Android versions prior to 12.
 Local photos can be selected using the `image_picker` package so that they are
 served via Bluetooth without requiring an external URL.
 Wi‑Fi Direct support is implemented with the `flutter_p2p_connection` plugin so
-that a voice call can be initiated even without an access point.
+that a voice call can be initiated even without an access point. Before
+creating a Wi‑Fi Direct group, call `askP2pPermissions()` from the plugin to
+request the required `ACCESS_FINE_LOCATION`, `CHANGE_WIFI_STATE` and
+`NEARBY_WIFI_DEVICES` permissions on recent Android versions.
 
 ## BLE Advertising Example
 

--- a/lib/nearby_ads_service.dart
+++ b/lib/nearby_ads_service.dart
@@ -195,6 +195,15 @@ class NearbyAdsService extends ChangeNotifier {
     if (selected != null) {
       await stopAdvertising();
     }
+    // Ensure Wi-Fi Direct permissions are granted before creating the group
+    if (!await _p2pHost.checkP2pPermissions()) {
+      await _p2pHost.askP2pPermissions();
+      if (!await _p2pHost.checkP2pPermissions()) {
+        state = AdsState.permissionDenied;
+        notifyListeners();
+        return;
+      }
+    }
     selected = ad;
     final hostState = await _p2pHost.createGroup(advertise: false);
     final updated = Announcement(


### PR DESCRIPTION
## Summary
- request Wi-Fi Direct permissions before creating the group
- update README with instructions on asking for P2P permissions

## Testing
- `dart format lib/nearby_ads_service.dart README.md` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b5bfa00c8327ac789dfcf8905518