### PR TITLE
Fix compile error with flutter_webrtc

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter_local_notifications: ^17.0.0
   permission_handler: ^11.0.0
   uuid: ^4.0.0
-  flutter_webrtc: ^0.11.6
+  flutter_webrtc: ^0.14.1
   flutter_p2p_connection: ^3.0.0
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- update `flutter_webrtc` to latest stable version
- ensure newline at end of `pubspec.yaml`

## Testing
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ab1e7ba48327b8e0026f69fb8140