### PR TITLE
Fix permission check

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,8 +10,8 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <!-- Permission for posting notifications on Android 13+ -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
    <application
         android:label="xchange"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,7 +87,7 @@ class AnnouncementProvider with ChangeNotifier {
       Permission.microphone,
       Permission.bluetoothScan,
       Permission.bluetoothConnect,
-      Permission.storage,
+      Permission.notification,
     ].request();
 
     if (!statuses[Permission.location]!.isGranted ||
@@ -95,7 +95,7 @@ class AnnouncementProvider with ChangeNotifier {
         !statuses[Permission.microphone]!.isGranted ||
         !statuses[Permission.bluetoothScan]!.isGranted ||
         !statuses[Permission.bluetoothConnect]!.isGranted ||
-        !statuses[Permission.storage]!.isGranted) {
+        !statuses[Permission.notification]!.isGranted) {
       print('Permissions nécessaires non accordées');
       WidgetsBinding.instance.addPostFrameCallback((_) {
         ScaffoldMessenger.of(navigatorKey.currentContext!).showSnackBar(


### PR DESCRIPTION
## Summary
- request `notification` permission instead of obsolete `storage` permission
- add POST_NOTIFICATIONS to the Android manifest

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6846aeffd2488327bcbfb5e4fcc2e5c7