### PR TITLE
Handle Bluetooth error and add Android wifi settings plugin

### DIFF
--- a/android/app/src/main/kotlin/com/example/xchange/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/xchange/MainActivity.kt
@@ -1,5 +1,27 @@
 package com.example.xchange
 
+import android.content.Intent
+import android.provider.Settings
+import androidx.annotation.NonNull
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private val CHANNEL = "xchange/wifi_settings"
+
+    override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "openWifiSettings" -> {
+                    val intent = Intent(Settings.ACTION_WIFI_SETTINGS)
+                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    startActivity(intent)
+                    result.success(null)
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -197,6 +197,16 @@ class AnnouncementProvider with ChangeNotifier {
       } catch (e) {
         print('Erreur lors de l\'initialisation : $e');
         retries--;
+        if (e.toString().contains('BLUETOOTH_DISABLED')) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            ScaffoldMessenger.of(navigatorKey.currentContext!).showSnackBar(
+              const SnackBar(
+                content:
+                    Text('Veuillez activer le Bluetooth pour utiliser le Wi-Fi Direct.'),
+              ),
+            );
+          });
+        }
         if (retries == 0) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             ScaffoldMessenger.of(navigatorKey.currentContext!).showSnackBar(


### PR DESCRIPTION
## Summary
- implement platform channel for opening Wi-Fi settings on Android
- show a snackbar if BLE advertising fails because Bluetooth is disabled

## Testing
- `dart format lib/main.dart android/app/src/main/kotlin/com/example/xchange/MainActivity.kt` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b6a5db98832791b7fece46a43cbb