### PR TITLE
Enable image attachments for announcements

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   uuid: ^4.0.0
   flutter_webrtc: ^0.14.1
   flutter_p2p_connection: ^3.0.0
+  image_picker: ^1.0.4
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- add `image_picker` dependency
- support optional Base64 image data in `Announcement`
- allow selecting or capturing an image when creating an announcement
- display attached images in announcements

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ba5791648327b814f26cc61d7196