### PR TITLE
Fix CardTheme type mismatch

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -447,7 +447,7 @@ class XchangeApp extends StatelessWidget {
         floatingActionButtonTheme: const FloatingActionButtonThemeData(
           backgroundColor: neonBlue,
         ),
-        cardTheme: const CardTheme(
+        cardTheme: const CardThemeData(
           elevation: 0,
           margin: EdgeInsets.all(8),
           color: Color(0xFF1A1A1A),


### PR DESCRIPTION
## Summary
- use `CardThemeData` to match the latest Flutter API

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846bf7a2fd083278d83ef220f5ee9e6