### PR TITLE
Fix Expanded widget usage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -601,50 +601,50 @@ class TweetLikeAnnouncement extends StatelessWidget {
                       ),
                     ),
                   const SizedBox(height: 8),
-                ],
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  if (!isCreated)
-                    IconButton(
-                      tooltip: 'Appeler',
-                      icon: const Icon(Icons.call),
-                      onPressed: () async {
-                        try {
-                          await Provider.of<AnnouncementProvider>(
-                            context,
-                            listen: false,
-                          ).initiateCall(
-                            announcement.broadcasterId,
-                            announcement.deviceAddress,
-                          );
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(content: Text('Appel initié')),
-                          );
-                        } catch (e) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(content: Text('Erreur : $e')),
-                          );
-                        }
-                      },
-                    ),
-                  IconButton(
-                    tooltip: 'Supprimer',
-                    icon: const Icon(Icons.delete),
-                    onPressed: () {
-                      if (isCreated) {
-                        Provider.of<AnnouncementProvider>(
-                          context,
-                          listen: false,
-                        ).deleteCreatedAnnouncement(announcement.id);
-                      } else {
-                        Provider.of<AnnouncementProvider>(
-                          context,
-                          listen: false,
-                        ).deleteReceivedAnnouncement(announcement.id);
-                      }
-                    },
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      if (!isCreated)
+                        IconButton(
+                          tooltip: 'Appeler',
+                          icon: const Icon(Icons.call),
+                          onPressed: () async {
+                            try {
+                              await Provider.of<AnnouncementProvider>(
+                                context,
+                                listen: false,
+                              ).initiateCall(
+                                announcement.broadcasterId,
+                                announcement.deviceAddress,
+                              );
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('Appel initié')),
+                              );
+                            } catch (e) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text('Erreur : $e')),
+                              );
+                            }
+                          },
+                        ),
+                      IconButton(
+                        tooltip: 'Supprimer',
+                        icon: const Icon(Icons.delete),
+                        onPressed: () {
+                          if (isCreated) {
+                            Provider.of<AnnouncementProvider>(
+                              context,
+                              listen: false,
+                            ).deleteCreatedAnnouncement(announcement.id);
+                          } else {
+                            Provider.of<AnnouncementProvider>(
+                              context,
+                              listen: false,
+                            ).deleteReceivedAnnouncement(announcement.id);
+                          }
+                        },
+                      ),
+                    ],
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- fix invalid usage of `Expanded` in `TweetLikeAnnouncement`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6846c59903708327b1a46ed704f5dd3e